### PR TITLE
Remove old Google Admin Login title

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A WordPress plugin that replaces the traditional admin login with Google OAuth2 
 
 1. Upload the `admin-login-sso` folder to the `/wp-content/plugins/` directory
 2. Activate the plugin through the 'Plugins' menu in WordPress
-3. Go to 'Settings > Google Admin Login' to configure the plugin
+3. Go to 'Settings > Admin Login SSO' to configure the plugin
 4. Set up Google OAuth credentials in the Google Cloud Console
 5. Enter your Client ID, Client Secret, and allowed domains
 6. Enable the plugin and test the login
@@ -38,7 +38,7 @@ A WordPress plugin that replaces the traditional admin login with Google OAuth2 
 
 ### Plugin Configuration
 
-1. Navigate to Settings → Google Admin Login in your WordPress admin
+1. Navigate to Settings → Admin Login SSO in your WordPress admin
 2. Enter the Google Client ID and Client Secret from your Google Cloud Console
 3. Add the allowed email domains (e.g., example.com, *.example.org)
 4. Enable the "Google-Only Admin Login" option

--- a/admin/class-admin-login-sso-admin.php
+++ b/admin/class-admin-login-sso-admin.php
@@ -62,7 +62,7 @@ class Admin_Login_SSO_Admin {
         // Add settings section
         add_settings_section(
             'admin_login_sso_settings_section',
-            __('Google Admin Login Settings', 'admin-login-sso'),
+            __('Admin Login SSO Settings', 'admin-login-sso'),
             array($this, 'settings_section_callback'),
             'admin_login_sso_settings'
         );

--- a/includes/class-admin-login-sso.php
+++ b/includes/class-admin-login-sso.php
@@ -150,8 +150,8 @@ class Admin_Login_SSO {
      */
     public function add_settings_page() {
         add_options_page(
-            __('Google Admin Login', 'admin-login-sso'),
-            __('Google Admin Login', 'admin-login-sso'),
+            __('Admin Login SSO', 'admin-login-sso'),
+            __('Admin Login SSO', 'admin-login-sso'),
             'manage_options',
             'admin-login-sso',
             array($this, 'render_settings_page')

--- a/readme.txt
+++ b/readme.txt
@@ -32,7 +32,7 @@ Admin Login SSO provides a secure and convenient way to replace the traditional 
 
 1. Upload the `admin-login-sso` folder to the `/wp-content/plugins/` directory
 2. Activate the plugin through the 'Plugins' menu in WordPress
-3. Go to 'Settings > Google Admin Login' to configure the plugin
+3. Go to 'Settings > Admin Login SSO' to configure the plugin
 4. Set up Google OAuth credentials in the Google Cloud Console
 5. Enter your Client ID, Client Secret, and allowed domains
 6. Enable the plugin and test the login


### PR DESCRIPTION
## Summary
- rename settings page from "Google Admin Login" to "Admin Login SSO"
- update documentation and admin text accordingly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686762baf3c0832fa59e7fdf7cc50b91