### PR TITLE
Modify classic login visibility setting

### DIFF
--- a/admin/class-admin-login-sso-admin.php
+++ b/admin/class-admin-login-sso-admin.php
@@ -111,7 +111,7 @@ class Admin_Login_SSO_Admin {
         
         add_settings_field(
             'admin_login_sso_show_classic_login',
-            __('Show classic login link', 'admin-login-sso'),
+            __('Show classic login form', 'admin-login-sso'),
             array($this, 'show_classic_login_callback'),
             'admin_login_sso_settings',
             'admin_login_sso_settings_section'
@@ -242,9 +242,9 @@ class Admin_Login_SSO_Admin {
         $show_classic = get_option('admin_login_sso_show_classic_login', '1');
         echo '<label for="admin_login_sso_show_classic_login">';
         echo '<input type="checkbox" id="admin_login_sso_show_classic_login" name="admin_login_sso_show_classic_login" value="1" ' . checked('1', $show_classic, false) . ' />';
-        echo esc_html__('Show "Use classic login" link on the login page', 'admin-login-sso');
+        echo esc_html__('Show classic login form on the login page', 'admin-login-sso');
         echo '</label>';
-        echo '<p class="description">' . esc_html__('When enabled, users can toggle between Google login and standard WordPress login.', 'admin-login-sso') . '</p>';
+        echo '<p class="description">' . esc_html__('When enabled, the traditional WordPress login form will be visible in addition to the Google login button.', 'admin-login-sso') . '</p>';
     }
 
     /**

--- a/includes/class-admin-login-sso-auth.php
+++ b/includes/class-admin-login-sso-auth.php
@@ -132,15 +132,19 @@ class Admin_Login_SSO_Auth {
             return;
         }
 
-        // Hide the default login form with CSS
-        echo '<style type="text/css">
-            #loginform p:not(.google-login-button-container):not(.classic-login-link-container),
-            #loginform .user-pass-wrap,
-            #loginform .forgetmenot,
-            #loginform .submit {
-                display: none;
-            }
-        </style>';
+        $show_classic = get_option('admin_login_sso_show_classic_login', '1');
+
+        if ($show_classic !== '1' && $show_classic !== true) {
+            // Hide the default login form when classic login is disabled
+            echo '<style type="text/css">
+                #loginform p:not(.google-login-button-container),
+                #loginform .user-pass-wrap,
+                #loginform .forgetmenot,
+                #loginform .submit {
+                    display: none;
+                }
+            </style>';
+        }
 
         // Add Google login button
         echo '<div class="google-login-button-container">';
@@ -150,64 +154,8 @@ class Admin_Login_SSO_Auth {
         echo '</a>';
         echo '</div>';
 
-        // Add classic login link if needed
-        if ($this->should_show_classic_login()) {
-            echo '<div class="classic-login-link-container">';
-            echo '<a href="#" class="classic-login-link">' . esc_html__('Use classic login', 'admin-login-sso') . '</a>';
-            echo '</div>';
-            
-            // Add JavaScript to toggle between login methods
-            echo '<script type="text/javascript">
-                document.addEventListener("DOMContentLoaded", function() {
-                    const classicLink = document.querySelector(".classic-login-link");
-                    if (classicLink) {
-                        classicLink.addEventListener("click", function(e) {
-                            e.preventDefault();
-                            const loginForm = document.getElementById("loginform");
-                            const passwordField = document.getElementById("user_pass");
-                            const usernameField = document.getElementById("user_login");
-                            loginForm.classList.toggle("show-classic-login");
-                            
-                            if (loginForm.classList.contains("show-classic-login")) {
-                                // Show classic login elements
-                                document.querySelectorAll("#loginform p:not(.google-login-button-container):not(.classic-login-link-container), #loginform .user-pass-wrap, #loginform .forgetmenot, #loginform .submit").forEach(function(el) {
-                                    el.style.display = "block";
-                                });
-                                
-                                // Enable password and username fields
-                                if (passwordField) {
-                                    passwordField.disabled = false;
-                                    passwordField.removeAttribute("disabled");
-                                    passwordField.readOnly = false;
-                                    passwordField.removeAttribute("readonly");
-                                }
-                                if (usernameField) {
-                                    usernameField.disabled = false;
-                                    usernameField.removeAttribute("disabled");
-                                    usernameField.readOnly = false;
-                                    usernameField.removeAttribute("readonly");
-                                }
-                                
-                                // Hide Google login button
-                                document.querySelector(".google-login-button-container").style.display = "none";
-                                
-                                classicLink.textContent = "' . esc_js(__('Use Google login', 'admin-login-sso')) . '";
-                            } else {
-                                // Hide classic login elements
-                                document.querySelectorAll("#loginform p:not(.google-login-button-container):not(.classic-login-link-container), #loginform .user-pass-wrap, #loginform .forgetmenot, #loginform .submit").forEach(function(el) {
-                                    el.style.display = "none";
-                                });
-                                
-                                // Show Google login button
-                                document.querySelector(".google-login-button-container").style.display = "block";
-                                
-                                classicLink.textContent = "' . esc_js(__('Use classic login', 'admin-login-sso')) . '";
-                            }
-                        });
-                    }
-                });
-            </script>';
-        }
+        // Classic login is shown automatically based on the admin setting,
+        // so no toggle link is required.
     }
 
     /**
@@ -759,37 +707,6 @@ class Admin_Login_SSO_Auth {
         return $is_admin;
     }
 
-    /**
-     * Check if classic login link should be shown
-     *
-     * @return bool True if classic login link should be shown
-     */
-    private function should_show_classic_login() {
-        // Check admin setting first
-        $show_classic = get_option('admin_login_sso_show_classic_login', '1');
-        
-        // Don't show if admin disabled it
-        if ($show_classic !== '1' && $show_classic !== true) {
-            return false;
-        }
-        
-        // Always show if plugin is disabled
-        if (!$this->is_enabled()) {
-            return true;
-        }
-        
-        // Show if user is already authenticated
-        if (is_user_logged_in()) {
-            return true;
-        }
-        
-        // Always show if there was an error to give users a fallback
-        if (isset($_GET['login']) && 'failed' === $_GET['login']) {
-            return true;
-        }
-        
-        return true; // Show by default if setting is enabled
-    }
 
     /**
      * Log error to debug.log if WP_DEBUG_LOG is enabled

--- a/includes/class-admin-login-sso.php
+++ b/includes/class-admin-login-sso.php
@@ -138,7 +138,7 @@ class Admin_Login_SSO {
             'admin_login_sso_show_classic_login',
             array(
                 'type' => 'boolean',
-                'description' => __('Show classic login link', 'admin-login-sso'),
+                'description' => __('Show classic login form', 'admin-login-sso'),
                 'sanitize_callback' => array($this, 'sanitize_checkbox'),
                 'default' => true,
             )

--- a/readme.txt
+++ b/readme.txt
@@ -64,7 +64,7 @@ No, this plugin only affects admin login (/wp-admin). Front-end login and other 
 
 = What if Google authentication fails? =
 
-The plugin provides a discreet fallback link ("Use classic login") that allows using the traditional WordPress login form if Google authentication fails.
+If the classic login form is enabled in the settings, users can sign in using the standard WordPress login form as a fallback.
 
 == Screenshots ==
 


### PR DESCRIPTION
## Summary
- rename setting to "Show classic login form"
- update admin page description and README
- simplify login form logic and always hide classic login when disabled

## Testing
- `php -l admin/class-admin-login-sso-admin.php`
- `php -l includes/class-admin-login-sso-auth.php`
- `php -l includes/class-admin-login-sso.php`
- `php -l admin-login-sso.php`


------
https://chatgpt.com/codex/tasks/task_e_686763c6ae8c832f851092acd8b46cf9